### PR TITLE
Add basic vitest test setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "astro dev --host",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "test": "vitest"
   },
   "dependencies": {
     "@astrojs/node": "^9.2.1",
@@ -15,5 +16,8 @@
     "astro": "^5.7.13",
     "flowbite": "^3.1.2",
     "tailwindcss": "^4.1.7"
+  },
+  "devDependencies": {
+    "vitest": "^1.0.0"
   }
 }

--- a/tests/themeToggle.test.js
+++ b/tests/themeToggle.test.js
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from 'astro/test';
+import ThemeToggle from '../src/components/ThemeToggle.astro';
+
+describe('ThemeToggle', () => {
+  it('toggles data-theme attribute when clicked', async () => {
+    const {element} = await mount(ThemeToggle);
+    const toggle = element.querySelector('.theme-toggle');
+    const html = document.documentElement;
+    const initial = html.getAttribute('data-theme');
+    toggle.dispatchEvent(new Event('click'));
+    expect(html.getAttribute('data-theme')).not.toBe(initial);
+  });
+});


### PR DESCRIPTION
## Summary
- add `vitest` and a `test` script
- create `themeToggle.test.js` to test theme toggling

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a025af608322b23c3ca1652b9eb6